### PR TITLE
feature(redeem): 新增卡密兑换邀请功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 *.pyc
 .venv/
 venv/
+data/*.db
+data/*.sqlite3

--- a/app.py
+++ b/app.py
@@ -1,12 +1,18 @@
 """ChatGPT Team 自动邀请"""
 
-import os
-import jwt
+import argparse
 import logging
-from datetime import datetime, timezone
-from flask import Flask, request, jsonify, send_from_directory
+import os
+import secrets
+import sqlite3
+import string
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+
+import jwt
 from curl_cffi import requests as cffi_requests
 from dotenv import load_dotenv
+from flask import Flask, jsonify, request, send_from_directory
 
 load_dotenv()
 logging.basicConfig(
@@ -24,7 +30,91 @@ OAI_CLIENT_VERSION = os.getenv(
 )
 PORT = int(os.getenv("PORT", "8080"))
 BASE_URL = "https://chatgpt.com/backend-api"
+DATABASE_PATH = os.getenv("DATABASE_PATH", "data/team_auto_invite.db")
+PENDING_TTL_SECONDS = int(os.getenv("REDEEM_PENDING_TTL_SECONDS", "300"))
+
 _token_cache = None
+
+
+def utc_now() -> datetime:
+    """返回当前的UTC时间"""
+    return datetime.now(timezone.utc)
+
+
+def utc_now_iso() -> str:
+    """返回一个ISO 8601 UTC时间戳"""
+    return utc_now().isoformat(timespec="seconds")
+
+
+def ensure_database_directory() -> None:
+    """必要时创建数据库目录"""
+    directory = os.path.dirname(DATABASE_PATH)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+
+def get_db_connection() -> sqlite3.Connection:
+    """创建一个具有类字典行的SQLite连接"""
+    conn = sqlite3.connect(DATABASE_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+@contextmanager
+def db_connection():
+    """生成一个SQLite连接，并确保之后将其关闭"""
+    conn = get_db_connection()
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def init_db() -> None:
+    """初始化兑换流程所使用的SQLite表"""
+    ensure_database_directory()
+    with db_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS redeem_codes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                code TEXT NOT NULL UNIQUE,
+                status TEXT NOT NULL DEFAULT 'unused',
+                reserved_by_email TEXT,
+                reserved_at TEXT,
+                used_by_email TEXT,
+                used_at TEXT,
+                disabled_at TEXT,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS invite_records (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL,
+                code TEXT,
+                invite_status TEXT NOT NULL,
+                invite_message TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+
+
+def validate_email(email: str) -> bool:
+    """验证基本的电子邮件格式"""
+    return "@" in email and "." in email.split("@")[-1]
+
+
+def normalize_redeem_code(code: str) -> str:
+    """将用户输入标准化为规范的兑换码格式"""
+    return code.strip().upper()
 
 
 def decode_token(token: str) -> dict:
@@ -40,9 +130,9 @@ def decode_token(token: str) -> dict:
             "exp": decoded.get("exp", 0),
             "valid": True,
         }
-    except Exception as e:
-        logger.error(f"JWT 解码失败: {e}")
-        return {"valid": False, "error": str(e)}
+    except Exception as exc:
+        logger.error("JWT 解码失败: %s", exc)
+        return {"valid": False, "error": str(exc)}
 
 
 def check_token_status() -> dict:
@@ -58,7 +148,7 @@ def check_token_status() -> dict:
     if not info["valid"]:
         return {"ok": False, "error": f"Token 解码失败: {info.get('error', '未知错误')}"}
 
-    if info["exp"] < int(datetime.now(timezone.utc).timestamp()):
+    if info["exp"] < int(utc_now().timestamp()):
         return {"ok": False, "error": "Token 已过期，请更新 .env 中的 JWT_TOKEN"}
     if info["plan_type"] != "team":
         return {"ok": False, "error": f"当前 Token 不是 Team 类型（当前: {info['plan_type']}）"}
@@ -82,24 +172,191 @@ def send_invite(account_id: str, email: str) -> dict:
     payload = {"email_addresses": [email], "role": "standard-user", "resend_emails": True}
 
     try:
-        resp = cffi_requests.post(url, json=payload, headers=headers, impersonate="chrome", timeout=30)
+        resp = cffi_requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            impersonate="chrome",
+            timeout=30,
+        )
         status = resp.status_code
 
         if status == 200:
-            logger.info(f"邀请发送成功: {email}")
+            logger.info("邀请发送成功: %s", email)
             return {"success": True, "message": "邀请发送成功，请检查邮箱"}
         if status == 409:
-            logger.warning(f"邀请冲突: {email} (已邀请或已是成员)")
+            logger.warning("邀请冲突: %s (已邀请或已是成员)", email)
             return {"success": False, "message": "该邮箱已被邀请或已是团队成员"}
         if status == 422:
-            logger.warning(f"团队已满，无法邀请: {email}")
+            logger.warning("团队已满，无法邀请: %s", email)
             return {"success": False, "message": "团队已满，无法继续邀请"}
 
-        logger.error(f"邀请失败 [{status}]: {resp.text}")
+        logger.error("邀请失败 [%s]: %s", status, resp.text)
         return {"success": False, "message": f"邀请失败 (HTTP {status})"}
-    except Exception as e:
-        logger.error(f"请求异常: {e}")
-        return {"success": False, "message": f"网络请求失败: {str(e)}"}
+    except Exception as exc:
+        logger.error("请求异常: %s", exc)
+        return {"success": False, "message": f"网络请求失败: {str(exc)}"}
+
+
+def record_invite_attempt(email: str, code: str | None, status: str, message: str) -> None:
+    """保留邀请记录，用于后续审计追溯"""
+    with db_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO invite_records (email, code, invite_status, invite_message, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (email, code, status, message, utc_now_iso()),
+        )
+
+
+def create_redeem_codes(codes: list[str]) -> dict:
+    """输入兑换码并跳过重复项"""
+    inserted: list[str] = []
+    skipped: list[str] = []
+    now = utc_now_iso()
+
+    with db_connection() as conn:
+        for raw_code in codes:
+            code = normalize_redeem_code(raw_code)
+            if not code:
+                continue
+
+            cursor = conn.execute(
+                """
+                INSERT OR IGNORE INTO redeem_codes (code, status, created_at)
+                VALUES (?, 'unused', ?)
+                """,
+                (code, now),
+            )
+            if cursor.rowcount:
+                inserted.append(code)
+            else:
+                skipped.append(code)
+
+    return {"inserted": inserted, "skipped": skipped}
+
+
+def generate_redeem_codes(count: int, prefix: str, length: int) -> list[str]:
+    """生成唯一的兑换码并将其存储在SQLite中"""
+    alphabet = string.ascii_uppercase + string.digits
+    normalized_prefix = normalize_redeem_code(prefix) or "TEAM"
+    inserted: list[str] = []
+    attempts = 0
+    max_attempts = max(count * 10, 20)
+
+    while len(inserted) < count and attempts < max_attempts:
+        attempts += 1
+        body = "".join(secrets.choice(alphabet) for _ in range(max(length, 6)))
+        code = f"{normalized_prefix}-{body}"
+        result = create_redeem_codes([code])
+        inserted.extend(result["inserted"])
+
+    return inserted
+
+
+def claim_redeem_code(code: str, email: str) -> dict:
+    """发送邀请前请预留一个兑换码"""
+    now = utc_now_iso()
+    stale_before = (utc_now() - timedelta(seconds=PENDING_TTL_SECONDS)).isoformat(
+        timespec="seconds"
+    )
+
+    with db_connection() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            """
+            SELECT status, reserved_at
+            FROM redeem_codes
+            WHERE code = ?
+            """,
+            (code,),
+        ).fetchone()
+
+        if row is None:
+            return {"ok": False, "status": "invalid_code", "message": "兑换码无效"}
+        if row["status"] == "disabled":
+            return {"ok": False, "status": "disabled_code", "message": "兑换码已禁用"}
+        if row["status"] == "used":
+            return {"ok": False, "status": "used_code", "message": "兑换码已被使用"}
+        if row["status"] == "pending" and row["reserved_at"] and row["reserved_at"] > stale_before:
+            return {"ok": False, "status": "pending_code", "message": "兑换码正在处理中，请稍后重试"}
+
+        conn.execute(
+            """
+            UPDATE redeem_codes
+            SET status = 'pending',
+                reserved_by_email = ?,
+                reserved_at = ?
+            WHERE code = ?
+            """,
+            (email, now, code),
+        )
+
+    return {"ok": True}
+
+
+def complete_redeem_code(code: str, email: str) -> None:
+    """将兑换码标记为永久已使用"""
+    with db_connection() as conn:
+        conn.execute(
+            """
+            UPDATE redeem_codes
+            SET status = 'used',
+                used_by_email = ?,
+                used_at = ?,
+                reserved_by_email = NULL,
+                reserved_at = NULL
+            WHERE code = ?
+            """,
+            (email, utc_now_iso(), code),
+        )
+
+
+def release_redeem_code(code: str) -> None:
+    """邀请失败后释放一个待处理的兑换码"""
+    with db_connection() as conn:
+        conn.execute(
+            """
+            UPDATE redeem_codes
+            SET status = 'unused',
+                reserved_by_email = NULL,
+                reserved_at = NULL
+            WHERE code = ? AND status = 'pending'
+            """,
+            (code,),
+        )
+
+
+def redeem_invite(email: str, code: str) -> dict:
+    """兑换代码，若有效则发送团队邀请"""
+    token_status = check_token_status()
+    if not token_status["ok"]:
+        record_invite_attempt(email, code, "token_error", token_status["error"])
+        return {
+            "success": False,
+            "message": token_status["error"],
+            "status_code": 503,
+        }
+
+    claim = claim_redeem_code(code, email)
+    if not claim["ok"]:
+        record_invite_attempt(email, code, claim["status"], claim["message"])
+        return {
+            "success": False,
+            "message": claim["message"],
+            "status_code": 400,
+        }
+
+    result = send_invite(token_status["account_id"], email)
+    if result["success"]:
+        complete_redeem_code(code, email)
+        record_invite_attempt(email, code, "success", result["message"])
+        return {"success": True, "message": result["message"], "status_code": 200}
+
+    release_redeem_code(code)
+    record_invite_attempt(email, code, "invite_failed", result["message"])
+    return {"success": False, "message": result["message"], "status_code": 400}
 
 
 @app.route("/")
@@ -111,12 +368,12 @@ def index():
 @app.route("/api/invite", methods=["POST"])
 def api_invite():
     """发送邀请"""
-    data = request.get_json()
+    data = request.get_json(silent=True)
     if not data or not data.get("email"):
         return jsonify({"success": False, "message": "请输入邮箱地址"}), 400
 
     email = data["email"].strip().lower()
-    if "@" not in email or "." not in email.split("@")[-1]:
+    if not validate_email(email):
         return jsonify({"success": False, "message": "邮箱格式不正确"}), 400
 
     token_status = check_token_status()
@@ -127,22 +384,98 @@ def api_invite():
     return jsonify(result), 200 if result["success"] else 400
 
 
+@app.route("/api/redeem", methods=["POST"])
+def api_redeem():
+    """兑换卡密并发送邀请"""
+    data = request.get_json(silent=True)
+    if not data or not data.get("email") or not data.get("code"):
+        return jsonify({"success": False, "message": "请输入邮箱地址和兑换码"}), 400
+
+    email = data["email"].strip().lower()
+    code = normalize_redeem_code(data["code"])
+
+    if not validate_email(email):
+        return jsonify({"success": False, "message": "邮箱格式不正确"}), 400
+    if not code:
+        return jsonify({"success": False, "message": "兑换码不能为空"}), 400
+
+    result = redeem_invite(email, code)
+    status_code = result.pop("status_code")
+    return jsonify(result), status_code
+
+
 @app.route("/api/health")
 def health():
     """健康检查"""
     token_status = check_token_status()
-    return jsonify({
-        "status": "ok" if token_status["ok"] else "error",
-        "token_valid": token_status["ok"],
-        "message": token_status.get("error", "服务正常"),
-    })
+    return jsonify(
+        {
+            "status": "ok" if token_status["ok"] else "error",
+            "token_valid": token_status["ok"],
+            "message": token_status.get("error", "服务正常"),
+        }
+    )
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Create a small CLI for seeding redeem codes."""
+    parser = argparse.ArgumentParser(description="ChatGPT Team 自动邀请")
+    subparsers = parser.add_subparsers(dest="command")
+
+    generate_parser = subparsers.add_parser("generate-codes", help="生成兑换码")
+    generate_parser.add_argument("--count", type=int, default=10, help="生成数量")
+    generate_parser.add_argument("--prefix", default="TEAM", help="兑换码前缀")
+    generate_parser.add_argument(
+        "--length",
+        type=int,
+        default=10,
+        help="兑换码随机部分长度",
+    )
+
+    add_parser = subparsers.add_parser("add-codes", help="手动添加兑换码")
+    add_parser.add_argument("codes", nargs="+", help="兑换码列表")
+    return parser
+
+
+def handle_cli() -> bool:
+    """Handle CLI commands and return whether a command was executed."""
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    if args.command == "generate-codes":
+        codes = generate_redeem_codes(args.count, args.prefix, args.length)
+        print(f"已生成 {len(codes)} 个兑换码:")
+        for code in codes:
+            print(code)
+        return True
+
+    if args.command == "add-codes":
+        result = create_redeem_codes(args.codes)
+        print(f"新增 {len(result['inserted'])} 个兑换码，跳过 {len(result['skipped'])} 个重复项")
+        for code in result["inserted"]:
+            print(code)
+        return True
+
+    return False
+
+
+def main() -> None:
+    """运行命令行界面或启动Flask应用程序"""
+    init_db()
+    if handle_cli():
+        return
+
+    status = check_token_status()
+    if status["ok"]:
+        logger.info("Token 有效 | 管理员邮箱: %s", status["email"])
+    else:
+        logger.warning("Token 问题: %s", status.get("error", "未知"))
+    logger.info("服务启动在端口 %s", PORT)
+    app.run(host="0.0.0.0", port=PORT, debug=False)
+
+
+init_db()
 
 
 if __name__ == "__main__":
-    status = check_token_status()
-    if status["ok"]:
-        logger.info(f"Token 有效 | 管理员邮箱: {status['email']}")
-    else:
-        logger.warning(f"Token 问题: {status.get('error', '未知')}")
-    logger.info(f"服务启动在端口 {PORT}")
-    app.run(host="0.0.0.0", port=PORT, debug=False)
+    main()

--- a/app.py
+++ b/app.py
@@ -117,6 +117,13 @@ def normalize_redeem_code(code: str) -> str:
     return code.strip().upper()
 
 
+def normalize_optional_string(value) -> str | None:
+    """验证输入是否为字符串，并返回去除首尾空白后的结果"""
+    if not isinstance(value, str):
+        return None
+    return value.strip()
+
+
 def decode_token(token: str) -> dict:
     """解码 JWT，提取 account_id 等信息"""
     try:
@@ -372,7 +379,11 @@ def api_invite():
     if not data or not data.get("email"):
         return jsonify({"success": False, "message": "请输入邮箱地址"}), 400
 
-    email = data["email"].strip().lower()
+    email = normalize_optional_string(data["email"])
+    if email is None:
+        return jsonify({"success": False, "message": "邮箱格式不正确"}), 400
+
+    email = email.lower()
     if not validate_email(email):
         return jsonify({"success": False, "message": "邮箱格式不正确"}), 400
 
@@ -391,8 +402,16 @@ def api_redeem():
     if not data or not data.get("email") or not data.get("code"):
         return jsonify({"success": False, "message": "请输入邮箱地址和兑换码"}), 400
 
-    email = data["email"].strip().lower()
-    code = normalize_redeem_code(data["code"])
+    email = normalize_optional_string(data["email"])
+    code = normalize_optional_string(data["code"])
+
+    if email is None:
+        return jsonify({"success": False, "message": "邮箱格式不正确"}), 400
+    if code is None:
+        return jsonify({"success": False, "message": "兑换码不能为空"}), 400
+
+    email = email.lower()
+    code = normalize_redeem_code(code)
 
     if not validate_email(email):
         return jsonify({"success": False, "message": "邮箱格式不正确"}), 400

--- a/static/index.html
+++ b/static/index.html
@@ -328,7 +328,7 @@
         </div>
         <div class="header">
             <h1>ChatGPT Team</h1>
-            <p>输入邮箱，获取 Team 席位邀请</p>
+            <p>输入邮箱和兑换码，兑换 Team 席位邀请</p>
         </div>
         <form id="inviteForm">
             <div class="form-group">
@@ -338,13 +338,20 @@
                         autocomplete="email" autofocus>
                 </div>
             </div>
+            <div class="form-group">
+                <label for="codeInput">兑换码</label>
+                <div class="input-wrap">
+                    <input type="text" id="codeInput" name="code" placeholder="TEAM-XXXXXXXXXX" required
+                        autocomplete="one-time-code">
+                </div>
+            </div>
             <button type="submit" class="btn-submit" id="submitBtn">
-                <span class="btn-text">发送邀请</span>
+                <span class="btn-text">立即兑换</span>
                 <div class="spinner"></div>
             </button>
         </form>
         <div id="message" class="message"></div>
-        <p class="footer-note">999人火车，请注意查收邮箱，报错就是死号了，或者席位满了</p>
+        <p class="footer-note">兑换成功后将自动发送邀请，请注意查收邮箱。</p>
         <a class="gh-link" href="https://github.com/Futureppo/team-auto-invite" target="_blank">
             <svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor">
                 <path
@@ -355,27 +362,31 @@
     </div>
     <script>
         const $ = id => document.getElementById(id);
-        const emailInput = $('emailInput'), submitBtn = $('submitBtn'), messageEl = $('message');
+        const emailInput = $('emailInput'), codeInput = $('codeInput'), submitBtn = $('submitBtn'), messageEl = $('message');
 
         $('inviteForm').addEventListener('submit', async e => {
             e.preventDefault();
             const email = emailInput.value.trim();
-            if (!email) return;
+            const code = codeInput.value.trim();
+            if (!email || !code) return;
 
             submitBtn.classList.add('loading');
             submitBtn.disabled = true;
             messageEl.className = 'message';
 
             try {
-                const resp = await fetch('/api/invite', {
+                const resp = await fetch('/api/redeem', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ email }),
+                    body: JSON.stringify({ email, code }),
                 });
                 const data = await resp.json();
                 messageEl.textContent = data.message;
                 messageEl.className = 'message ' + (data.success ? 'success' : 'error');
-                if (data.success) emailInput.value = '';
+                if (data.success) {
+                    emailInput.value = '';
+                    codeInput.value = '';
+                }
             } catch {
                 messageEl.textContent = '网络请求失败，请稍后重试';
                 messageEl.className = 'message error';

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,190 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import app as invite_app
+
+
+class RedeemApiTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_database_path = invite_app.DATABASE_PATH
+        self.original_token_cache = invite_app._token_cache
+
+        invite_app.DATABASE_PATH = str(Path(self.temp_dir.name) / "test.db")
+        invite_app._token_cache = None
+        invite_app.init_db()
+
+        self.client = invite_app.app.test_client()
+
+    def tearDown(self) -> None:
+        invite_app.DATABASE_PATH = self.original_database_path
+        invite_app._token_cache = self.original_token_cache
+        self.temp_dir.cleanup()
+
+    def fetch_code_row(self, code: str):
+        with invite_app.db_connection() as conn:
+            return conn.execute(
+                """
+                SELECT code, status, reserved_by_email, used_by_email
+                FROM redeem_codes
+                WHERE code = ?
+                """,
+                (code,),
+            ).fetchone()
+
+    def fetch_invite_records(self):
+        with invite_app.db_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT email, code, invite_status, invite_message
+                FROM invite_records
+                ORDER BY id
+                """
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def test_create_redeem_codes_normalizes_and_skips_duplicates(self) -> None:
+        result = invite_app.create_redeem_codes([" test-001 ", "TEST-001", "test-002"])
+
+        self.assertEqual(result["inserted"], ["TEST-001", "TEST-002"])
+        self.assertEqual(result["skipped"], ["TEST-001"])
+
+    def test_redeem_api_marks_code_used_after_successful_invite(self) -> None:
+        invite_app.create_redeem_codes(["success-001"])
+
+        with patch.object(
+            invite_app,
+            "check_token_status",
+            return_value={"ok": True, "account_id": "acct_123", "email": "admin@example.com"},
+        ), patch.object(
+            invite_app,
+            "send_invite",
+            return_value={"success": True, "message": "邀请发送成功，请检查邮箱"},
+        ):
+            response = self.client.post(
+                "/api/redeem",
+                json={"email": "user@example.com", "code": "success-001"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"success": True, "message": "邀请发送成功，请检查邮箱"})
+
+        code_row = self.fetch_code_row("SUCCESS-001")
+        self.assertEqual(code_row["status"], "used")
+        self.assertEqual(code_row["used_by_email"], "user@example.com")
+
+        self.assertEqual(
+            self.fetch_invite_records(),
+            [
+                {
+                    "email": "user@example.com",
+                    "code": "SUCCESS-001",
+                    "invite_status": "success",
+                    "invite_message": "邀请发送成功，请检查邮箱",
+                }
+            ],
+        )
+
+    def test_redeem_api_releases_code_when_invite_fails(self) -> None:
+        invite_app.create_redeem_codes(["fail-001"])
+
+        with patch.object(
+            invite_app,
+            "check_token_status",
+            return_value={"ok": True, "account_id": "acct_123", "email": "admin@example.com"},
+        ), patch.object(
+            invite_app,
+            "send_invite",
+            return_value={"success": False, "message": "团队已满，无法继续邀请"},
+        ):
+            response = self.client.post(
+                "/api/redeem",
+                json={"email": "user@example.com", "code": "fail-001"},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"success": False, "message": "团队已满，无法继续邀请"})
+
+        code_row = self.fetch_code_row("FAIL-001")
+        self.assertEqual(code_row["status"], "unused")
+        self.assertIsNone(code_row["reserved_by_email"])
+        self.assertIsNone(code_row["used_by_email"])
+
+        self.assertEqual(
+            self.fetch_invite_records(),
+            [
+                {
+                    "email": "user@example.com",
+                    "code": "FAIL-001",
+                    "invite_status": "invite_failed",
+                    "invite_message": "团队已满，无法继续邀请",
+                }
+            ],
+        )
+
+    def test_redeem_api_returns_400_for_invalid_code(self) -> None:
+        with patch.object(
+            invite_app,
+            "check_token_status",
+            return_value={"ok": True, "account_id": "acct_123", "email": "admin@example.com"},
+        ):
+            response = self.client.post(
+                "/api/redeem",
+                json={"email": "user@example.com", "code": "missing-code"},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"success": False, "message": "兑换码无效"})
+        self.assertEqual(
+            self.fetch_invite_records(),
+            [
+                {
+                    "email": "user@example.com",
+                    "code": "MISSING-CODE",
+                    "invite_status": "invalid_code",
+                    "invite_message": "兑换码无效",
+                }
+            ],
+        )
+
+    def test_redeem_api_returns_503_when_token_is_invalid(self) -> None:
+        invite_app.create_redeem_codes(["token-001"])
+
+        with patch.object(
+            invite_app,
+            "check_token_status",
+            return_value={"ok": False, "error": "Token 解码失败: Invalid header padding"},
+        ):
+            response = self.client.post(
+                "/api/redeem",
+                json={"email": "user@example.com", "code": "token-001"},
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response.get_json(),
+            {"success": False, "message": "Token 解码失败: Invalid header padding"},
+        )
+
+        code_row = self.fetch_code_row("TOKEN-001")
+        self.assertEqual(code_row["status"], "unused")
+        self.assertIsNone(code_row["reserved_by_email"])
+        self.assertIsNone(code_row["used_by_email"])
+
+        self.assertEqual(
+            self.fetch_invite_records(),
+            [
+                {
+                    "email": "user@example.com",
+                    "code": "TOKEN-001",
+                    "invite_status": "token_error",
+                    "invite_message": "Token 解码失败: Invalid header padding",
+                }
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -185,6 +185,45 @@ class RedeemApiTestCase(unittest.TestCase):
             ],
         )
 
+    def test_redeem_api_rejects_non_string_code(self) -> None:
+        with patch.object(
+            invite_app,
+            "check_token_status",
+            return_value={"ok": True, "account_id": "acct_123", "email": "admin@example.com"},
+        ):
+            response = self.client.post(
+                "/api/redeem",
+                json={"email": "user@example.com", "code": 123},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"success": False, "message": "兑换码不能为空"})
+        self.assertEqual(self.fetch_invite_records(), [])
+
+    def test_redeem_api_rejects_non_string_email(self) -> None:
+        with patch.object(
+            invite_app,
+            "check_token_status",
+            return_value={"ok": True, "account_id": "acct_123", "email": "admin@example.com"},
+        ):
+            response = self.client.post(
+                "/api/redeem",
+                json={"email": ["user@example.com"], "code": "valid-001"},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"success": False, "message": "邮箱格式不正确"})
+        self.assertEqual(self.fetch_invite_records(), [])
+
+    def test_invite_api_rejects_non_string_email(self) -> None:
+        response = self.client.post(
+            "/api/invite",
+            json={"email": {"address": "user@example.com"}},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"success": False, "message": "邮箱格式不正确"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #1 

## 变更概述

这个 PR 为项目增加了基于卡密的 Team 邀请兑换流程。

用户现在需要输入“邮箱 + 兑换码”完成兑换。后端会校验兑换码、发送邀请，并将兑换码状态和邀请记录持久化到 SQLite 中。

## 主要改动

- 增加 SQLite 持久化，用于保存兑换码和邀请记录
- 新增 `POST /api/redeem` 接口，支持卡密兑换后发送邀请
- 保留原有 `POST /api/invite`，避免直接破坏兼容性
- 增加兑换码状态流转逻辑：
  - 邀请前先将兑换码标记为 `pending`
  - 邀请成功后标记为 `used`
  - 邀请失败后释放回 `unused`
- 增加本地卡密初始化命令：
  - `generate-codes`
  - `add-codes`
- 前端页面从“仅邮箱”改为“邮箱 + 兑换码”
- 增加自动化测试，覆盖兑换主流程
- 优化 SQLite 连接管理，避免未关闭连接告警

## 变更原因

当前项目只适合直接邀请，不适合做基于卡密的受控发放。这个 PR 提供了一个最小可用实现，在不移除旧接口的前提下，补齐卡密兑换能力。

## 测试视频
鉴于并没有去整真实的 JWT_TOKEN ，会在这个阶段卡住，所以本地简单做了一个 mock 方案来测试（并未放在此次 PR 中），简单测试效果如下： 

https://github.com/user-attachments/assets/1083f3e8-54b1-4f45-92d4-b8af7e2308be


## 测试方式
补充了当前这个 PR 的测试:

```bash
source .venv/bin/activate
python -m unittest discover -s tests
